### PR TITLE
feat: collapse side panels

### DIFF
--- a/src/components/DraggableViewContainer.tsx
+++ b/src/components/DraggableViewContainer.tsx
@@ -1,8 +1,15 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FixedLengthArray } from '../util/TypeUtil';
-import DraggableViewSection from './DraggableViewSection';
-import styles from '../css/RMLMappingEditor.module.scss';
-import useWindowEvent from '../hooks/useWindowEvent';
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { FixedLengthArray } from "../util/TypeUtil";
+import DraggableViewSection from "./DraggableViewSection";
+import styles from "../css/RMLMappingEditor.module.scss";
+import useWindowEvent from "../hooks/useWindowEvent";
 
 const RESIZE_TIMEOUT_DURATION = 100;
 const MINIMUM_DIMENSION = 130;
@@ -11,114 +18,217 @@ export interface DraggableViewContainerProps<T extends number> {
   viewContent: FixedLengthArray<ReactNode, T>;
   defaultViewDimensions: FixedLengthArray<number | undefined, T>;
   vertical?: boolean;
-  additionalClasses?: string[],
+  additionalClasses?: string[];
+  collapsedIndices: number[];
 }
 
-function DraggableViewContainer<T extends number>({ 
+function DraggableViewContainer<T extends number>({
   viewContent,
   defaultViewDimensions,
-  vertical, 
+  vertical,
   additionalClasses = [],
+  collapsedIndices = [],
 }: DraggableViewContainerProps<T>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const resizeTimeout = useRef<ReturnType<typeof setTimeout>>();
-  const [dimensions, setDimensions] = useState<FixedLengthArray<number | undefined, T>>(defaultViewDimensions);
+  const [dimensions, setDimensions] = useState<
+    FixedLengthArray<number | undefined, T>
+  >(defaultViewDimensions);
 
   const updateDimensions = useCallback(() => {
     const totalContainerDimension = vertical
-      ? containerRef.current!.offsetHeight
-      : containerRef.current!.offsetWidth;
+      ? containerRef.current?.offsetHeight
+      : containerRef.current?.offsetWidth;
 
-    const usedDimensions = dimensions.reduce((sum: number, dim) => (dim !== undefined ? sum + dim : sum), 0);
-    const leftoverSpace = totalContainerDimension - usedDimensions;
-    const leftoverCount = dimensions.filter(dim => dim === undefined).length;
-    const newDimensions = dimensions.map(dim => {
+    const usedDimensions = dimensions.reduce((sum: number, dim, index) => {
+      if (collapsedIndices.includes(index) || dim === undefined) return sum;
+      if (dim === 0 && !collapsedIndices.includes(index))
+        return sum + MINIMUM_DIMENSION;
+      return sum + dim;
+    }, 0);
+
+    const leftoverSpace = (totalContainerDimension ?? 0) - usedDimensions;
+    const leftoverCount = dimensions.filter(
+      (dim, index) => dim === undefined || collapsedIndices.includes(index)
+    ).length;
+
+    const newDimensions = dimensions.map((dim, index) => {
+      if (collapsedIndices.includes(index)) return 0;
+      if (dim === 0 && !collapsedIndices.includes(index))
+        return MINIMUM_DIMENSION;
       return dim === undefined ? leftoverSpace / leftoverCount : dim;
     }) as unknown as FixedLengthArray<number, T>;
-    
-    setDimensions(newDimensions);
-  }, [dimensions, vertical]);
 
-  const hasUndefinedDimensions = useMemo(() => dimensions.some(dim => dim === undefined), [dimensions]);
+    setDimensions(newDimensions);
+  }, [vertical, dimensions, collapsedIndices]);
+
+  const hasUndefinedDimensions = useMemo(
+    () => dimensions.some((dim) => dim === undefined),
+    [dimensions]
+  );
+
+  const handleCollapseChange = useCallback(() => {
+    setDimensions((dimensions) => {
+      let collapsedItemsSpace = 0;
+      // Space occupied by items that were previously collapsed and have now been opened
+      let uncollapsedItemsSpace = 0;
+      let openItemsCount = 0;
+      dimensions.forEach((dim, index) => {
+        if (collapsedIndices.includes(index) && dim !== undefined && dim > 0) {
+          collapsedItemsSpace += dim;
+        } else if (
+          !collapsedIndices.includes(index) &&
+          dim !== undefined &&
+          dim === 0
+        ) {
+          uncollapsedItemsSpace +=
+            defaultViewDimensions[index] ?? MINIMUM_DIMENSION;
+        }
+        if (!collapsedIndices.includes(index) && (dim === undefined || dim > 0))
+          openItemsCount++;
+      });
+
+      // uncollapsedItemsCount includes both, the items that just opened and the ones that were open already. openItemsCount only includes the items that were open while some (or none) were collapsed.
+      const uncollapsedItemsCount = dimensions.length - collapsedIndices.length;
+
+      const newDimensions = dimensions.map((dim, index) => {
+        if (collapsedIndices.includes(index)) return 0;
+        if (dim === undefined) {
+          console.log("dim is undefined");
+          return dim;
+        }
+        if (dim === 0 && !collapsedIndices.includes(index)) {
+          return defaultViewDimensions[index] ?? MINIMUM_DIMENSION;
+        }
+        const newDim =
+          dim +
+          (collapsedItemsSpace ?? 0) / (uncollapsedItemsCount ?? 1) -
+          uncollapsedItemsSpace / openItemsCount;
+        console.log({ newDim  });
+        return newDim;
+      }) as unknown as FixedLengthArray<number | undefined, T>;
+      console.log({
+        collapsedItemsSpace,
+        newDimensions,
+        collapsedIndices,
+        uncollapsedItemsCount,
+        openItemsCount,
+        uncollapsedItemsSpace,
+      });
+      return newDimensions;
+    });
+  }, [collapsedIndices, defaultViewDimensions]);
 
   useEffect(() => {
-    if (hasUndefinedDimensions && containerRef.current) {
+    handleCollapseChange();
+  }, [collapsedIndices, handleCollapseChange]);
+
+  useEffect(() => {
+    // console.log({ hasUndefinedDimensions, dimensions });
+    if (containerRef.current && hasUndefinedDimensions) {
       updateDimensions();
     }
   }, [hasUndefinedDimensions, updateDimensions]);
 
   const classes = useMemo(() => {
     return [
-      styles.draggableViewContainer, 
-      vertical ? 'vertical' : 'horizonatal', 
-      ...additionalClasses
-    ].join(' ')
+      styles.draggableViewContainer,
+      vertical ? "vertical" : "horizonatal",
+      ...additionalClasses,
+    ].join(" ");
   }, [vertical, additionalClasses]);
 
-  const style = useMemo(() => (
-    hasUndefinedDimensions 
-      ? {
-          display: 'flex', 
-          flexDirection: vertical ? 'column' : 'row'
-        } as const
-      : { position: 'relative' } as const
-  ), [hasUndefinedDimensions, vertical]);
+  const style = useMemo(
+    () =>
+      hasUndefinedDimensions
+        ? ({
+            display: "flex",
+            flexDirection: vertical ? "column" : "row",
+          } as const)
+        : ({ position: "relative" } as const),
+    [hasUndefinedDimensions, vertical]
+  );
 
   const offsets = useMemo(() => {
     return dimensions.map((dim, index) => {
-      return dimensions.slice(0, index).reduce((sum: number, dim) => sum + (dim ?? 0), 0);
-    })
-  }, [dimensions]);
-
-  const handleDimensionChange = useCallback((changedIndex: number, dimensionChange: number) => {
-    let canApplyDimensionChange = (dimensions[changedIndex] ?? 0) + dimensionChange > MINIMUM_DIMENSION &&
-      (dimensions[changedIndex + 1] ?? 0) - dimensionChange > MINIMUM_DIMENSION
-    if (canApplyDimensionChange) {
-      setDimensions((dimensions) => dimensions.map((dim: number | undefined, index) => {
-        if (index === changedIndex) {
-          return (dim ?? 0) + dimensionChange;
-        } else if (index === changedIndex + 1) {
-          return (dim ?? 0) - dimensionChange;
+      return dimensions.slice(0, index).reduce((sum: number, dim) => {
+        if (collapsedIndices.includes(index - 1)) {
+          return sum;
         }
-        return dim;
-      }) as unknown as FixedLengthArray<number | undefined, T>);
-    }
-  }, [dimensions]);
+        return sum + (dim ?? 0);
+      }, 0);
+    });
+  }, [dimensions, collapsedIndices]);
+
+  const handleDimensionChange = useCallback(
+    (changedIndex: number, dimensionChange: number) => {
+      let canApplyDimensionChange =
+        (dimensions[changedIndex] ?? 0) + dimensionChange > MINIMUM_DIMENSION &&
+        (dimensions[changedIndex + 1] ?? 0) - dimensionChange >
+          MINIMUM_DIMENSION;
+
+      if (canApplyDimensionChange) {
+        setDimensions(
+          (dimensions) =>
+            dimensions.map((dim: number | undefined, index) => {
+              if (index === changedIndex) {
+                return (dim ?? 0) + dimensionChange;
+              } else if (index === changedIndex + 1) {
+                return (dim ?? 0) - dimensionChange;
+              }
+              return dim;
+            }) as unknown as FixedLengthArray<number | undefined, T>
+        );
+      }
+    },
+    [dimensions]
+  );
 
   const recalcWidths = useCallback(() => {
     const totalContainerDimension = vertical
       ? containerRef.current!.offsetHeight
       : containerRef.current!.offsetWidth;
 
-    const indiciesOfPreferedWidths = defaultViewDimensions.reduce((arr: number[], oldDimension, index) => {
-      if (oldDimension !== undefined) {
-        arr.push(index);
-      }
-      return arr;
-    }, []);
+    const indiciesOfPreferedWidths = defaultViewDimensions.reduce(
+      (arr: number[], oldDimension, index) => {
+        if (oldDimension !== undefined && !collapsedIndices.includes(index)) {
+          arr.push(index);
+        }
+        return arr;
+      },
+      []
+    );
 
     let totalPreferredSpace = 0;
     let totalNonPreferedSpace = 0;
     dimensions.forEach((oldDimension, index) => {
-      if (indiciesOfPreferedWidths.includes(index)) {
+      if (
+        indiciesOfPreferedWidths.includes(index) &&
+        !collapsedIndices.includes(index)
+      ) {
         totalPreferredSpace += oldDimension ?? 0;
       } else {
         totalNonPreferedSpace += oldDimension ?? 0;
       }
     });
 
-    const newLeftoverSpace = Math.abs(totalContainerDimension - totalPreferredSpace);
+    const totalUnpreferredSpace = totalContainerDimension - totalPreferredSpace;
 
     const newDimensions = dimensions.map((oldDimension, index) => {
       if (indiciesOfPreferedWidths.includes(index)) {
-        return oldDimension
+        return oldDimension;
       } else {
-        return newLeftoverSpace * ( (oldDimension ?? 0) / totalNonPreferedSpace )
+        return (
+          Math.abs(totalUnpreferredSpace) *
+          ((oldDimension ?? 0) / totalNonPreferedSpace)
+        );
       }
     });
 
-    setDimensions(newDimensions as unknown as FixedLengthArray<number | undefined, T>);
-  }, [defaultViewDimensions, dimensions, vertical]);
+    setDimensions(
+      newDimensions as unknown as FixedLengthArray<number | undefined, T>
+    );
+  }, [defaultViewDimensions, dimensions, vertical, collapsedIndices]);
 
   const onResize = useCallback(() => {
     if (resizeTimeout.current) {
@@ -128,25 +238,21 @@ function DraggableViewContainer<T extends number>({
     resizeTimeout.current = setTimeout(recalcWidths, RESIZE_TIMEOUT_DURATION);
   }, [recalcWidths]);
 
-  useWindowEvent('resize', true, onResize);
+  useWindowEvent("resize", true, onResize);
 
   return (
-    <div 
-      ref={containerRef}
-      className={classes}
-      style={style}
-    >
-      { viewContent.map((content, index) => (
-        <DraggableViewSection 
+    <div ref={containerRef} className={classes} style={style}>
+      {viewContent.map((content, index) => (
+        <DraggableViewSection
           key={index}
           onDimensionChange={handleDimensionChange.bind(null, index)}
           dimensionsComputed={!hasUndefinedDimensions}
-          offset={offsets[index]} 
-          dimension={dimensions[index]} 
+          offset={offsets[index]}
+          dimension={dimensions[index]}
           vertical={vertical}
           isLast={index === viewContent.length - 1}
         >
-          { content }
+          {content}
         </DraggableViewSection>
       ))}
     </div>

--- a/src/components/DraggableViewContainer.tsx
+++ b/src/components/DraggableViewContainer.tsx
@@ -83,7 +83,6 @@ function DraggableViewContainer<T extends number>({
           collapsedItemsSpace += dim;
         } else if (
           !collapsedIndices.includes(index) &&
-          dim !== undefined &&
           dim === 0
         ) {
           uncollapsedItemsSpace +=

--- a/src/components/DraggableViewContainer.tsx
+++ b/src/components/DraggableViewContainer.tsx
@@ -5,11 +5,11 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
-import { FixedLengthArray } from "../util/TypeUtil";
-import DraggableViewSection from "./DraggableViewSection";
-import styles from "../css/RMLMappingEditor.module.scss";
-import useWindowEvent from "../hooks/useWindowEvent";
+} from 'react';
+import { FixedLengthArray } from '../util/TypeUtil';
+import DraggableViewSection from './DraggableViewSection';
+import styles from '../css/RMLMappingEditor.module.scss';
+import useWindowEvent from '../hooks/useWindowEvent';
 
 const RESIZE_TIMEOUT_DURATION = 100;
 const MINIMUM_DIMENSION = 130;
@@ -81,10 +81,7 @@ function DraggableViewContainer<T extends number>({
       dimensions.forEach((dim, index) => {
         if (collapsedIndices.includes(index) && dim !== undefined && dim > 0) {
           collapsedItemsSpace += dim;
-        } else if (
-          !collapsedIndices.includes(index) &&
-          dim === 0
-        ) {
+        } else if (!collapsedIndices.includes(index) && dim === 0) {
           uncollapsedItemsSpace +=
             defaultViewDimensions[index] ?? MINIMUM_DIMENSION;
         }
@@ -132,19 +129,19 @@ function DraggableViewContainer<T extends number>({
   const classes = useMemo(() => {
     return [
       styles.draggableViewContainer,
-      vertical ? "vertical" : "horizonatal",
+      vertical ? 'vertical' : 'horizonatal',
       ...additionalClasses,
-    ].join(" ");
+    ].join(' ');
   }, [vertical, additionalClasses]);
 
   const style = useMemo(
     () =>
       hasUndefinedDimensions
         ? ({
-            display: "flex",
-            flexDirection: vertical ? "column" : "row",
+            display: 'flex',
+            flexDirection: vertical ? 'column' : 'row',
           } as const)
-        : ({ position: "relative" } as const),
+        : ({ position: 'relative' } as const),
     [hasUndefinedDimensions, vertical]
   );
 
@@ -237,7 +234,7 @@ function DraggableViewContainer<T extends number>({
     resizeTimeout.current = setTimeout(recalcWidths, RESIZE_TIMEOUT_DURATION);
   }, [recalcWidths]);
 
-  useWindowEvent("resize", true, onResize);
+  useWindowEvent('resize', true, onResize);
 
   return (
     <div ref={containerRef} className={classes} style={style}>

--- a/src/components/DraggableViewContainer.tsx
+++ b/src/components/DraggableViewContainer.tsx
@@ -41,7 +41,9 @@ function DraggableViewContainer<T extends number>({
       : containerRef.current?.offsetWidth;
 
     const usedDimensions = dimensions.reduce((sum: number, dim, index) => {
-      if (collapsedIndices.includes(index) || dim === undefined) return sum;
+      if (collapsedIndices.includes(index) || dim === undefined) {
+        return sum;
+      }
       if (dim === 0 && !collapsedIndices.includes(index))
         return sum + MINIMUM_DIMENSION;
       return sum + dim;
@@ -49,13 +51,16 @@ function DraggableViewContainer<T extends number>({
 
     const leftoverSpace = (totalContainerDimension ?? 0) - usedDimensions;
     const leftoverCount = dimensions.filter(
-      (dim, index) => dim === undefined || collapsedIndices.includes(index)
+      (dim, index) => dim === undefined
     ).length;
 
     const newDimensions = dimensions.map((dim, index) => {
-      if (collapsedIndices.includes(index)) return 0;
-      if (dim === 0 && !collapsedIndices.includes(index))
+      if (collapsedIndices.includes(index)) {
+        return 0;
+      }
+      if (dim === 0 && !collapsedIndices.includes(index)) {
         return MINIMUM_DIMENSION;
+      }
       return dim === undefined ? leftoverSpace / leftoverCount : dim;
     }) as unknown as FixedLengthArray<number, T>;
 
@@ -84,17 +89,22 @@ function DraggableViewContainer<T extends number>({
           uncollapsedItemsSpace +=
             defaultViewDimensions[index] ?? MINIMUM_DIMENSION;
         }
-        if (!collapsedIndices.includes(index) && (dim === undefined || dim > 0))
+        if (
+          !collapsedIndices.includes(index) &&
+          (dim === undefined || dim > 0)
+        ) {
           openItemsCount++;
+        }
       });
 
       // uncollapsedItemsCount includes both, the items that just opened and the ones that were open already. openItemsCount only includes the items that were open while some (or none) were collapsed.
       const uncollapsedItemsCount = dimensions.length - collapsedIndices.length;
 
       const newDimensions = dimensions.map((dim, index) => {
-        if (collapsedIndices.includes(index)) return 0;
+        if (collapsedIndices.includes(index)) {
+          return 0;
+        }
         if (dim === undefined) {
-          console.log("dim is undefined");
           return dim;
         }
         if (dim === 0 && !collapsedIndices.includes(index)) {
@@ -104,17 +114,8 @@ function DraggableViewContainer<T extends number>({
           dim +
           (collapsedItemsSpace ?? 0) / (uncollapsedItemsCount ?? 1) -
           uncollapsedItemsSpace / openItemsCount;
-        console.log({ newDim  });
         return newDim;
       }) as unknown as FixedLengthArray<number | undefined, T>;
-      console.log({
-        collapsedItemsSpace,
-        newDimensions,
-        collapsedIndices,
-        uncollapsedItemsCount,
-        openItemsCount,
-        uncollapsedItemsSpace,
-      });
       return newDimensions;
     });
   }, [collapsedIndices, defaultViewDimensions]);
@@ -124,7 +125,6 @@ function DraggableViewContainer<T extends number>({
   }, [collapsedIndices, handleCollapseChange]);
 
   useEffect(() => {
-    // console.log({ hasUndefinedDimensions, dimensions });
     if (containerRef.current && hasUndefinedDimensions) {
       updateDimensions();
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,26 +1,28 @@
-import ThemeToggle from "./ThemeToggle";
-import styles from "../css/RMLMappingEditor.module.scss";
-
-function Header({
-  collapsedItems,
-  unCollapse,
-}: {
-  collapsedItems: string[];
+import ThemeToggle from './ThemeToggle';
+import styles from '../css/RMLMappingEditor.module.scss';
+import { ReactElement } from 'react';
+interface HeaderProps {
+  collapsedItems: Array<string | { name: string; icon: ReactElement }>;
   unCollapse: (item: string) => void;
-}) {
+}
+
+function Header({ collapsedItems, unCollapse }: HeaderProps) {
   return (
     <div className={styles.header}>
       <div className={styles.logo}>RML Mapping Editor</div>
-      {collapsedItems.map((item) => (
-        <button
-          key={item}
-          onClick={unCollapse.bind(null, item)}
-          className={`${styles.panelHeaderButton}`}
-        >
-          {item[0].toUpperCase()}
-          {item.slice(1)} Panel
-        </button>
-      ))}
+      {collapsedItems.map((item) => {
+        const name = typeof item === 'string' ? item : item.name;
+        const icon = typeof item === 'string' ? null : item.icon;
+        return (
+          <button
+            key={name}
+            onClick={unCollapse.bind(null, name)}
+            className={`${styles.panelHeaderButton}`}
+          >
+            {icon ?? `${name[0].toUpperCase()}${name.slice(1)} Panel`}
+          </button>
+        );
+      })}
       <ThemeToggle />
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,29 @@
-import ThemeToggle from './ThemeToggle';
-import styles from '../css/RMLMappingEditor.module.scss';
+import ThemeToggle from "./ThemeToggle";
+import styles from "../css/RMLMappingEditor.module.scss";
 
-function Header() {
+function Header({
+  collapsedItems,
+  unCollapse,
+}: {
+  collapsedItems: string[];
+  unCollapse: (item: string) => void;
+}) {
   return (
     <div className={styles.header}>
       <div className={styles.logo}>RML Mapping Editor</div>
+      {collapsedItems.map((item) => (
+        <button
+          key={item}
+          onClick={unCollapse.bind(null, item)}
+          className={`${styles.panelHeaderButton}`}
+        >
+          {item[0].toUpperCase()}
+          {item.slice(1)} Panel
+        </button>
+      ))}
       <ThemeToggle />
     </div>
-  )
+  );
 }
 
 export default Header;

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,36 +1,44 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import InputContext, { INPUT_TYPES } from '../contexts/InputContext';
-import styles from '../css/RMLMappingEditor.module.scss';
-import CodeEditor from './CodeEditor';
-import { ReactComponent as PlusIcon } from '../images/plus.svg';
-import { ReactComponent as DownArrow } from '../images/down-arrow.svg';
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import InputContext, { INPUT_TYPES } from "../contexts/InputContext";
+import styles from "../css/RMLMappingEditor.module.scss";
+import CodeEditor from "./CodeEditor";
+import { ReactComponent as PlusIcon } from "../images/plus.svg";
+import { ReactComponent as DownArrow } from "../images/down-arrow.svg";
+import { PanelType } from "../util/TypeUtil";
 
 const views = {
-  inputs: 'Input Files',
+  inputs: "Input Files",
   // functions: 'Functions',
-}
+};
 
 export interface InputPanelProps {
   addNewInput: () => void;
+  collapse: (collapseItem: PanelType) => void;
 }
 
-function InputPanel({ addNewInput }: InputPanelProps) {
+function InputPanel({ addNewInput, collapse }: InputPanelProps) {
   const [view, setView] = useState(views.inputs);
   const { inputFiles, setInputFiles } = useContext(InputContext);
-  const [selectedInputFileIndex, setSelectedInputFileIndex] = useState<number>();
+  const [selectedInputFileIndex, setSelectedInputFileIndex] =
+    useState<number>();
   const selectedInputFile = useMemo(
-    () => selectedInputFileIndex !== undefined ? inputFiles[selectedInputFileIndex] : undefined, 
+    () =>
+      selectedInputFileIndex !== undefined
+        ? inputFiles[selectedInputFileIndex]
+        : undefined,
     [inputFiles, selectedInputFileIndex]
   );
-  const [prevInputFilesLength, setPrevInputFilesLength] = useState<number>(inputFiles.length);
+  const [prevInputFilesLength, setPrevInputFilesLength] = useState<number>(
+    inputFiles.length
+  );
 
   const inputType = useMemo(() => {
     if (selectedInputFile) {
-      if (selectedInputFile.name.endsWith('.json')) {
+      if (selectedInputFile.name.endsWith(".json")) {
         return INPUT_TYPES.json;
-      } else if (selectedInputFile.name.endsWith('.xml')) {
+      } else if (selectedInputFile.name.endsWith(".xml")) {
         return INPUT_TYPES.xml;
-      } else if (selectedInputFile.name.endsWith('.csv')) {
+      } else if (selectedInputFile.name.endsWith(".csv")) {
         return INPUT_TYPES.csv;
       }
     }
@@ -38,24 +46,32 @@ function InputPanel({ addNewInput }: InputPanelProps) {
 
   const changeToInputView = useCallback(() => setView(views.inputs), [setView]);
 
-  const updateSelectedInputFile = useCallback((input: string) => {
-    if (selectedInputFileIndex !== undefined) {
-      setInputFiles(inputFiles.map((inputFile, index) => {
-        if (index === selectedInputFileIndex) {
-          return { ...inputFile, contents: input }
-        }
-        return inputFile;
-      }))
-    }
-  }, [selectedInputFileIndex, setInputFiles, inputFiles]);
+  const updateSelectedInputFile = useCallback(
+    (input: string) => {
+      if (selectedInputFileIndex !== undefined) {
+        setInputFiles(
+          inputFiles.map((inputFile, index) => {
+            if (index === selectedInputFileIndex) {
+              return { ...inputFile, contents: input };
+            }
+            return inputFile;
+          })
+        );
+      }
+    },
+    [selectedInputFileIndex, setInputFiles, inputFiles]
+  );
 
-  const closeSelectedInputFile = useCallback(() => setSelectedInputFileIndex(undefined), []);
+  const closeSelectedInputFile = useCallback(
+    () => setSelectedInputFileIndex(undefined),
+    []
+  );
 
   useEffect(() => {
     if (inputFiles.length !== prevInputFilesLength) {
       setPrevInputFilesLength(inputFiles.length);
       if (inputFiles.length > prevInputFilesLength) {
-        setSelectedInputFileIndex(inputFiles.length-1);
+        setSelectedInputFileIndex(inputFiles.length - 1);
       }
     }
   }, [inputFiles, prevInputFilesLength]);
@@ -63,40 +79,69 @@ function InputPanel({ addNewInput }: InputPanelProps) {
   return (
     <div className={styles.inputPanel}>
       <div className={styles.panelHeader}>
-        <button onClick={changeToInputView} className={`${styles.panelHeaderButton} ${view === views.inputs ? styles.panelHeaderButtonSelected : ''}`}>Input Files</button>
+        <button
+          onClick={changeToInputView}
+          className={`${styles.panelHeaderButton} ${
+            view === views.inputs ? styles.panelHeaderButtonSelected : ""
+          }`}
+        >
+          Input Files
+        </button>
         <div className={styles.stretch}></div>
-        <button onClick={addNewInput} className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton}`}>
+        <button
+          onClick={collapse.bind(null, "input")}
+          className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton} ${styles.collapsePanelButtonLeft}`}
+        >
+          <DownArrow />
+        </button>
+        <button
+          onClick={addNewInput}
+          className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton}`}
+        >
           <PlusIcon />
         </button>
         {/* <button onClick={changeToJSONInput} className={`${styles.panelHeaderButton} ${inputType === INPUT_TYPES.json ? styles.panelHeaderButtonSelected : ''}`}>JSON</button>
         <button onClick={changeToXMLInput} className={`${styles.panelHeaderButton} ${inputType === INPUT_TYPES.xml ? styles.panelHeaderButtonSelected : ''}`}>XML</button> */}
       </div>
-      { !selectedInputFile && (
+      {!selectedInputFile && (
         <div className={styles.inputFilesList}>
-          { inputFiles.map((inputFile, index) => {
-            return <div className={styles.inputFile} onClick={setSelectedInputFileIndex.bind(null, index)}>{inputFile.name}</div>
+          {inputFiles.map((inputFile, index) => {
+            return (
+              <div
+                key={index}
+                className={styles.inputFile}
+                onClick={setSelectedInputFileIndex.bind(null, index)}
+              >
+                {inputFile.name}
+              </div>
+            );
           })}
         </div>
       )}
-      { selectedInputFile && (
+      {selectedInputFile && (
         <>
           <div className={styles.panelHeader}>
-            <button onClick={closeSelectedInputFile} className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton}`}>
+            <button
+              onClick={closeSelectedInputFile}
+              className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton}`}
+            >
               <DownArrow className={styles.backArrow} />
             </button>
-            <div className={styles.inputSourceName}>{selectedInputFile.name}</div>
+            <div className={styles.inputSourceName}>
+              {selectedInputFile.name}
+            </div>
           </div>
-          <CodeEditor 
+          <CodeEditor
             key={selectedInputFileIndex}
             mode={inputType}
-            code={selectedInputFile.contents ?? ''}
+            code={selectedInputFile.contents ?? ""}
             onChange={updateSelectedInputFile}
             classes={styles.mappingEditorCodeView}
           />
         </>
       )}
     </div>
-  )
+  );
 }
 
 export default InputPanel;

--- a/src/components/OutputPanel.tsx
+++ b/src/components/OutputPanel.tsx
@@ -1,14 +1,27 @@
-import { useContext, useMemo } from 'react';
-import OutputContext from '../contexts/OutputContext';
-import styles from '../css/RMLMappingEditor.module.scss';
-import CodeEditor from './CodeEditor';
+import { useContext, useMemo } from "react";
+import OutputContext from "../contexts/OutputContext";
+import styles from "../css/RMLMappingEditor.module.scss";
+import CodeEditor from "./CodeEditor";
+import { ReactComponent as DownArrow } from "../images/down-arrow.svg";
+import { PanelType } from "../util/TypeUtil";
 
-function OutputPanel() {
+function OutputPanel({ collapse }: { collapse: (item: PanelType) => void }) {
   const { output } = useContext(OutputContext);
-  const stringOutput = useMemo(() => JSON.stringify(output, undefined, 2), [output]);
+  const stringOutput = useMemo(
+    () => JSON.stringify(output, undefined, 2),
+    [output]
+  );
   return (
     <div className={styles.outputPanel}>
-      <CodeEditor 
+      <div className={styles.panelHeader}>
+        <button
+          onClick={collapse.bind(null, "output")}
+          className={`${styles.panelHeaderButton} ${styles.iconPanelHeaderButton} ${styles.collapsePanelButtonRight}`}
+        >
+          <DownArrow />
+        </button>
+      </div>
+      <CodeEditor
         key={stringOutput}
         code={stringOutput}
         locked
@@ -16,7 +29,7 @@ function OutputPanel() {
         classes={styles.mappingEditorCodeView}
       />
     </div>
-  )
+  );
 }
 
 export default OutputPanel;

--- a/src/components/RMLMappingEditor.tsx
+++ b/src/components/RMLMappingEditor.tsx
@@ -1,44 +1,55 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ThemeContext, { THEMES } from '../contexts/ThemeContext';
-import styles from '../css/RMLMappingEditor.module.scss';
-import { FixedLengthArray } from '../util/TypeUtil';
-import DraggableViewContainer from './DraggableViewContainer';
-import EditorPanel from './EditorPanel';
-import Header from './Header';
-import InputPanel from './InputPanel';
-import OutputPanel from './OutputPanel';
-import type { NodeObject } from 'jsonld'; 
-import MappingContext from '../contexts/MappingContext';
-import InputContext, { DEFAULT_INPUT_FILE_BY_TYPE, INPUT_TYPES, InputFile } from '../contexts/InputContext';
-import OutputContext from '../contexts/OutputContext';
-import * as RMLMapper from '@comake/rmlmapper-js';
-import NewInputModal from './NewInputModal';
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ThemeContext, { THEMES } from "../contexts/ThemeContext";
+import styles from "../css/RMLMappingEditor.module.scss";
+import { FixedLengthArray, PanelType } from "../util/TypeUtil";
+import DraggableViewContainer from "./DraggableViewContainer";
+import EditorPanel from "./EditorPanel";
+import Header from "./Header";
+import InputPanel from "./InputPanel";
+import OutputPanel from "./OutputPanel";
+import type { NodeObject } from "jsonld";
+import MappingContext from "../contexts/MappingContext";
+import InputContext, {
+  DEFAULT_INPUT_FILE_BY_TYPE,
+  INPUT_TYPES,
+  InputFile,
+} from "../contexts/InputContext";
+import OutputContext from "../contexts/OutputContext";
+import * as RMLMapper from "@comake/rmlmapper-js";
+import NewInputModal from "./NewInputModal";
 
 const BASE_PANEL_WIDTH = 400;
 const RUN_MAPPING_TIMEOUT_DURATION = 500;
 
 const defaultMapping = {
   "@context": {
-    "rr": "http://www.w3.org/ns/r2rml#",
-    "rml": "http://semweb.mmlab.be/ns/rml#",
+    rr: "http://www.w3.org/ns/r2rml#",
+    rml: "http://semweb.mmlab.be/ns/rml#",
   },
-  '@type': 'http://www.w3.org/ns/r2rml#TriplesMap',
+  "@type": "http://www.w3.org/ns/r2rml#TriplesMap",
   "rml:logicalSource": {
     "@type": "rml:LogicalSource",
     "rml:iterator": "$",
     "rml:referenceFormulation": "http://semweb.mmlab.be/ns/ql#JSONPath",
-    "rml:source": "input.json"
+    "rml:source": "input.json",
   },
   "rr:subject": "https://example.com/mappingSubject",
-  "rr:predicateObjectMap": [
-
-  ]
+  "rr:predicateObjectMap": [],
 };
 
-const defaultInputFiles = [{
-  name: 'input.json',
-  contents: DEFAULT_INPUT_FILE_BY_TYPE[INPUT_TYPES.json],
-}];
+const defaultInputFiles = [
+  {
+    name: "input.json",
+    contents: DEFAULT_INPUT_FILE_BY_TYPE[INPUT_TYPES.json],
+  },
+];
 
 export function RMLMappingEditor() {
   const [theme, setTheme] = useState(THEMES.dark);
@@ -48,30 +59,32 @@ export function RMLMappingEditor() {
   const [output, setOutput] = useState<NodeObject[]>();
   const runMappingTimeout = useRef<ReturnType<typeof setTimeout>>();
   const [addingNewInput, setAddingNewInput] = useState(false);
-  
-  const themeContext = useMemo(
-    () => ({ theme, setTheme }), 
-    [ theme, setTheme ],
-  );
+  const [collapsed, setCollapsed] = useState<string[]>([]);
+
+  const themeContext = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
 
   const inputContext = useMemo(
-    () => ({ inputFiles, setInputFiles }), 
-    [ inputFiles, setInputFiles ],
+    () => ({ inputFiles, setInputFiles }),
+    [inputFiles, setInputFiles]
   );
 
   const outputContext = useMemo(
-    () => ({ output, setOutput }), 
-    [ output, setOutput ],
+    () => ({ output, setOutput }),
+    [output, setOutput]
   );
 
   const mappingContext = useMemo(
-    () => ({ mapping, setMapping, mappingError, setMappingError }), 
-    [ mapping, setMapping, mappingError, setMappingError ],
+    () => ({ mapping, setMapping, mappingError, setMappingError }),
+    [mapping, setMapping, mappingError, setMappingError]
   );
 
-  const defaultBodyWidths = useMemo(() => 
-    [BASE_PANEL_WIDTH, undefined, BASE_PANEL_WIDTH] as FixedLengthArray<number | undefined, 3>, 
-    [],
+  const defaultBodyWidths = useMemo(
+    () =>
+      [BASE_PANEL_WIDTH, undefined, BASE_PANEL_WIDTH] as FixedLengthArray<
+        number | undefined,
+        3
+      >,
+    []
   );
 
   const addNewInput = useCallback(() => setAddingNewInput(true), []);
@@ -82,11 +95,14 @@ export function RMLMappingEditor() {
       setMappingError(undefined);
 
       const inputFilesByName = inputFiles.reduce((obj, inputFile) => {
-        return { ...obj, [inputFile.name]: inputFile.contents }
+        return { ...obj, [inputFile.name]: inputFile.contents };
       }, {});
 
       try {
-        const result = await RMLMapper.parseJsonLd(mapping, inputFilesByName) as NodeObject[];
+        const result = (await RMLMapper.parseJsonLd(
+          mapping,
+          inputFilesByName
+        )) as NodeObject[];
         setOutput(result);
       } catch (error: unknown) {
         console.log(error);
@@ -99,32 +115,82 @@ export function RMLMappingEditor() {
     if (runMappingTimeout.current) {
       clearTimeout(runMappingTimeout.current);
     }
-    runMappingTimeout.current = setTimeout(runMapping, RUN_MAPPING_TIMEOUT_DURATION);
+    runMappingTimeout.current = setTimeout(
+      runMapping,
+      RUN_MAPPING_TIMEOUT_DURATION
+    );
   }, [inputFiles, mapping]);
+  const collapseItem = (panelToCollapse: PanelType) => {
+    setCollapsed((curr) => [...curr, panelToCollapse]);
+  };
 
-  const content = useMemo(() => ([
-    <InputPanel addNewInput={addNewInput} />,
-    <EditorPanel />,
-    <OutputPanel />
-  ] as FixedLengthArray<ReactNode, 3>), [addNewInput]);
+  const {
+    panelOrder,
+    Panels,
+  }: { panelOrder: PanelType[]; Panels: Record<PanelType, ReactNode> } =
+    useMemo(
+      () => ({
+        panelOrder: ["input", "editor", "output"] as PanelType[],
+        Panels: {
+          input: (
+            <InputPanel addNewInput={addNewInput} collapse={collapseItem} />
+          ),
+          editor: <EditorPanel />,
+          output: <OutputPanel collapse={collapseItem} />,
+        },
+      }),
+      [addNewInput]
+    );
+
+  const content = useMemo(
+    () =>
+      panelOrder.map((key) => {
+        if (collapsed.includes(key)) {
+          return (<div></div>) as ReactNode;
+        }
+        return Panels[key] as ReactNode;
+      }) as unknown as FixedLengthArray<ReactNode, 3>,
+    [collapsed, Panels, panelOrder]
+  );
+
+  const unCollapse = useCallback(
+    (item: string) => {
+      setCollapsed((curr) => curr.filter((panelName) => panelName !== item));
+    },
+    [setCollapsed]
+  );
+  const collapsedIndices = useMemo(() => {
+    const resIndices: number[] = [];
+    panelOrder.forEach((item, index) => {
+      if (collapsed.includes(item)) resIndices.push(index);
+    });
+    return resIndices;
+  }, [collapsed, panelOrder]);
 
   return (
     <ThemeContext.Provider value={themeContext}>
       <MappingContext.Provider value={mappingContext}>
         <InputContext.Provider value={inputContext}>
           <OutputContext.Provider value={outputContext}>
-            <div className={theme === THEMES.dark ? styles.rmlEditorDark : styles.rmlEditorLight}>
-              <Header />
+            <div
+              className={
+                theme === THEMES.dark
+                  ? styles.rmlEditorDark
+                  : styles.rmlEditorLight
+              }
+            >
+              <Header collapsedItems={collapsed} unCollapse={unCollapse} />
               <DraggableViewContainer
                 defaultViewDimensions={defaultBodyWidths}
                 viewContent={content}
                 additionalClasses={[styles.body]}
+                collapsedIndices={collapsedIndices}
               />
-              { addingNewInput && <NewInputModal close={closeNewInputModal}/>}
+              {addingNewInput && <NewInputModal close={closeNewInputModal} />}
             </div>
           </OutputContext.Provider>
         </InputContext.Provider>
       </MappingContext.Provider>
     </ThemeContext.Provider>
-  )
+  );
 }

--- a/src/css/RMLMappingEditor.module.scss
+++ b/src/css/RMLMappingEditor.module.scss
@@ -14,11 +14,11 @@
 .rmlEditorDark {
   composes: rmlEditor;
   color-scheme: dark;
-  
+
   --header-icon-color: rgb(227, 230, 234);
   --secondary-icon-color: rgb(84, 88, 93);
   --primary-icon-color: rgb(142, 146, 150);
-  
+
   --primary-text-color: rgb(215, 218, 224);
   --secondary-text-color: #abb2bf;
   --tertiary-text-color: rgba(215, 218, 224, 0.5);
@@ -133,18 +133,18 @@
 
 .draggableViewSection::after {
   z-index: 2;
-  content: '';
+  content: "";
   -webkit-transition: background-color 0.2s;
   transition: background-color 0.2s;
 }
 
-.draggableViewSection .dragHandle, 
+.draggableViewSection .dragHandle,
 .draggableViewSection::after {
   position: absolute;
   background-color: transparent;
 }
 
-.draggableViewSection.dragHandleLongHover::after, 
+.draggableViewSection.dragHandleLongHover::after,
 .draggableViewSection.dragging::after {
   background-color: var(--context-menu-border-color);
 }
@@ -163,7 +163,7 @@
 
 .draggableViewContainer:not(.vertical) {
   .draggableViewSection > .dragHandle,
-  .draggableViewSection.dragHandleLongHover::after, 
+  .draggableViewSection.dragHandleLongHover::after,
   .draggableViewSection.dragging::after {
     height: 100%;
     right: -3px;
@@ -175,7 +175,7 @@
 
 .panel {
   background-color: var(--side-panel-background-color);
-  height:100%;
+  height: 100%;
 }
 
 .stretch {
@@ -229,7 +229,7 @@
   display: flex;
   align-items: center;
   width: 100%;
-  height:32px;
+  height: 32px;
   padding: 0 6px;
   border-bottom: 1px solid var(--header-border-color);
 }
@@ -275,7 +275,7 @@
   align-items: center;
   justify-content: flex-end;
   width: 100%;
-  height:32px;
+  height: 32px;
   padding: 0 10px;
   font-size: 13px;
   color: var(--warning-text-color);
@@ -300,7 +300,7 @@
   padding: 8px;
 }
 
-.inputFile  {
+.inputFile {
   cursor: pointer;
   padding: 7px 10px;
   border-radius: 5px;
@@ -332,7 +332,7 @@
   top: 0;
   bottom: 0;
   z-index: 101;
-  background-color: rgba(0,0,0,0.5);
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -349,10 +349,10 @@
   flex-direction: column;
   background-color: var(--main-background-color);
   border: 1px solid var(--dropdown-border-color);
-
 }
 
-.modalHeader, .modalFooter {
+.modalHeader,
+.modalFooter {
   padding: 20px 20px 15px 20px;
   display: flex;
   align-items: center;
@@ -416,6 +416,15 @@
 
   &:hover {
     background-color: var(--button-selected-color);
-    color: var(--button-selected-text-color)
+    color: var(--button-selected-text-color);
   }
 }
+
+.collapsePanelButtonLeft {
+  transform: rotate(90deg);
+}
+
+.collapsePanelButtonRight {
+  transform: rotate(-90deg);
+}
+

--- a/src/util/TypeUtil.ts
+++ b/src/util/TypeUtil.ts
@@ -13,3 +13,5 @@ Pick<TObj, Exclude<keyof TObj, ArrayLengthMutationKeys>>
 export type ValueOf<T> = T[keyof T];
 
 export type ClickEvent = React.MouseEvent<HTMLButtonElement>;
+
+export type PanelType = "input" | "editor" | "output";


### PR DESCRIPTION
This will fix [issue#6](https://github.com/comake/rml-mapping-editor/issues/6).

Collapsed panels can be opened by clicking on their respective names that appear on the top right after they've been collapsed.